### PR TITLE
Fix MongoDB 2.6 compatibility in mongo_stats.sh

### DIFF
--- a/scripts/mongo_stats.sh
+++ b/scripts/mongo_stats.sh
@@ -152,6 +152,12 @@ function mongoCron(slowQueryKillAge, nonYieldingKillAge) {
   }
 
   function calcLockChange() {
+    var serverStatus = db.serverStatus();
+    if (serverStatus.version.startsWith("2")) {
+        // Crude version check: serverStatus().locks.*.acquireCount doesn't
+        // exist in mongodb before version 3.0
+        return;
+    }
     var honeydb = getHoneycombDB();
     var myname = db.serverStatus().repl ? db.serverStatus().repl.me : db.getMongo().host;
     data.hostname = myname;


### PR DESCRIPTION
Seems `acquireCount` was added to `serverStatus.locks()` in MongoDB 3.0, so
skip trying to read it for 2.6 (see #3).