### PR TITLE
Add support for regex query entry in log file

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Mongodbtools contributors:
 
 Chris Toshok
+Wan Bachtiar

--- a/logparser/internal/logparser/log_line.go
+++ b/logparser/internal/logparser/log_line.go
@@ -692,6 +692,20 @@ func (p *LogLineParser) parseJSONValue() (interface{}, error) {
 		} else {
 			return nil, fmt.Errorf("unexpected start of JSON value: %s", value)
 		}
+	case firstCharInVal == '/':
+		// Case for regex query field value
+		// for example: { field: /^numbersOrLetters.?.?$/ }
+		var exp string
+		if err := p.expect('/'); err != nil {
+			return nil, err
+		}
+		if exp, err = p.readUntilRune('/'); err != nil {
+			return nil, err
+		}
+		if err = p.expect('/'); err != nil {
+			return nil, err
+		}
+		value = "/" + exp + "/"
 	default:
 		return nil, fmt.Errorf("unexpected start character for JSON value of field: %c", firstCharInVal)
 	}


### PR DESCRIPTION
For example, `mongod` log entry such as: 

```
2017-08-14T00:09:17.028-0400 I COMMAND  [conn555555] query foo.bar query: { $query: { fieldA: /^123456789.?\/test.?$/ } } planSummary: IXSCAN { fieldA: 1, fieldB: 1 } ntoreturn:0 ntoskip:0 nscanned:2 nscannedObjects:1 keyUpdates:0 writeConflicts:0 numYields:1 nreturned:1 reslen:1337 locks:{ Global: { acquireCount: { r: 4 } }, Database: { acquireCount: { r: 2 } }, Collection: { acquireCount: { r: 2 } } } 134ms
```
