### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @honeycombio/telemetry-team


### PR DESCRIPTION
Adds a `CODEOWNERS` files that tags @honeycombio/telemetry-team as reviewers for issues & PRs.